### PR TITLE
Minor fix for Ubuntu users as env looks for a binary named "bash --norc" 

### DIFF
--- a/sbt
+++ b/sbt
@@ -1,10 +1,11 @@
-#!/usr/bin/env bash --norc
+#!/usr/bin/env bash
 #
 # A more capable sbt runner, coincidentally also called sbt.
 # Author: Paul Phillips <paulp@typesafe.com>
 
 # this seems to cover the bases on OSX, and someone will
 # have to tell me about the others.
+set --norc
 get_script_path () {
   local path="$1"
   [[ -L "$path" ]] || { echo "$path" ; return; }


### PR DESCRIPTION
Minor fix for Ubuntu users as env looks for a binary named "bash --norc" in the $PATH and fails with "No such file or directory". (Ubuntu 11.04)
