### PR TITLE
Fixes Ubuntu rc issue.

### DIFF
--- a/sbt
+++ b/sbt
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash --norc
+#!/usr/bin/env bash
 #
 # A more capable sbt runner, coincidentally also called sbt.
 # Author: Paul Phillips <paulp@typesafe.com>


### PR DESCRIPTION
IIRC .bashrc is never read for a script unless it's explicitly told to do so & this currently causes an invalid option error on Ubuntu.
