### PR TITLE
Fixed shebang line for Linux.

### DIFF
--- a/sbt
+++ b/sbt
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash --norc
+#!/bin/bash
 #
 # A more capable sbt runner, coincidentally also called sbt.
 # Author: Paul Phillips <paulp@typesafe.com>


### PR DESCRIPTION
Linux (or at least Ubuntu 11.10) doesn't like the #!/usr/bin/env bash -norc.  It give an error of "/usr/bin/env: bash --norc: No such file or directory".

There shouldn't be any problem just using /bin/bash.
