### PR TITLE
Calling a directory .sbt in the project/ directory causes SBT to go into...

### DIFF
--- a/sbt
+++ b/sbt
@@ -44,7 +44,7 @@ declare -r sbt_snapshot_baseurl="http://typesafe.artifactoryonline.com/typesafe/
 declare -r default_java_opts="-Dfile.encoding=UTF8"
 declare -r default_sbt_opts="-XX:+CMSClassUnloadingEnabled"
 declare -r default_sbt_mem=1536
-declare -r noshare_opts="-Dsbt.global.base=project/.sbt -Dsbt.boot.directory=project/.boot -Dsbt.ivy.home=project/.ivy"
+declare -r noshare_opts="-Dsbt.global.base=project/.sbtboot -Dsbt.boot.directory=project/.boot -Dsbt.ivy.home=project/.ivy"
 declare -r sbt_opts_file=".sbtopts"
 declare -r latest_28="2.8.2"
 declare -r latest_29="2.9.1"


### PR DESCRIPTION
... legacy plugin project mode and breaks version resolution.   This fixes that issue by calling the directory .sbtboot instead of .sbt.  Note: why are .sbtboot and .boot separate?  A question for others.
