### PR TITLE
execRunner should exec.

### DIFF
--- a/sbt
+++ b/sbt
@@ -104,7 +104,7 @@ execRunner () {
     echo ""
   }
 
-  "$@"
+  exec "$@"
 }
 
 echoerr () {


### PR DESCRIPTION
This avoids having a stray bash process that's not useful for anything.
