### PR TITLE
Respect JAVA_HOME over the PATH configuration (if JAVA_HOME is set).

### DIFF
--- a/sbt
+++ b/sbt
@@ -58,6 +58,8 @@ declare -r script_name="$(basename $script_path)"
 declare java_cmd=java
 declare sbt_mem=$default_sbt_mem
 
+[ -e "$JAVA_HOME/bin/java" ] && java_cmd="$JAVA_HOME/bin/java"
+
 unset sbt_jar sbt_dir sbt_create sbt_version sbt_snapshot
 unset scala_version
 unset java_home


### PR DESCRIPTION
Generally speaking, Java build tools pull from JAVA_HOME _first_ and then PATH if JAVA_HOME is unset.  Aside from the mere convention, this makes it much easier to force SBT to use a different version of JAVA without having to entirely reconfigure one's local environment.
