### PR TITLE
fix relative-path-to-sbt logic in get_script_path()

### DIFF
--- a/sbt
+++ b/sbt
@@ -69,7 +69,7 @@ get_script_path () {
   if [[ "${target:0:1}" == "/" ]]; then
     echo "$target"
   else
-    echo "$(basename $path)/$target"
+    echo "$(dirname $path)/$target"
   fi
 }
 


### PR DESCRIPTION
Hi,

Looks like get_script_path(), when provided with a relative symlink on linux, doesn't use the basename of the path when creating the relative path to sbt:

$ readlink /home/martin/bin/sbt
../src/sbt-extras/sbt
$ sbt -sbt-create
++ local path=/home/martin/bin/sbt
++ [[ -L /home/martin/bin/sbt ]]
+++ readlink /home/martin/bin/sbt
++ local target=../src/sbt-extras/sbt
++ [[ . == \/ ]]
++ echo /home/martin/bin/sbt/../src/sbt-extras/sbt
Detected sbt version 0.11.2
Downloading sbt launcher 0.11.2:
  From  http://typesafe.artifactoryonline.com/typesafe/ivy-releases/org.scala-tools.sbt/sbt-launch/0.11.2/sbt-launch.jar
    To  /home/martin/bin/sbt/../src/sbt-extras/.lib/0.11.2/sbt-launch.jar
mkdir: cannot create directory `/home/martin/bin/sbt': Not a directory
Download failed. Obtain the jar manually and place it at /home/martin/bin/sbt/../src/sbt-extras/.lib/0.11.2/sbt-launch.jar

Since we are called as get_script_path /home/martin/bin/sbt, we want to append the readlink output to the basename of $1, as in this patch.

The patch works for me; hope it can be of use.
