### PR TITLE
0.12 should be 0.12.0

### DIFF
--- a/sbt
+++ b/sbt
@@ -4,7 +4,7 @@
 # Author: Paul Phillips <paulp@typesafe.com>
 
 # todo - make this dynamic
-declare -r sbt_release_version=0.12
+declare -r sbt_release_version=0.12.0
 declare -r sbt_snapshot_version=0.13.0-SNAPSHOT
 
 unset sbt_jar sbt_dir sbt_create sbt_snapshot sbt_launch_dir


### PR DESCRIPTION
A version of 0.12 gives:

```
Downloading sbt launcher 0.12:
  From  http://typesafe.artifactoryonline.com/typesafe/ivy-releases/org.scala-sbt/sbt-launch/0.12/sbt-launch.jar
    To  /Users/paul/bin/.lib/0.12/sbt-launch.jar
Download failed. Obtain the jar manually and place it at /Users/paul/bin/.lib/0.12/sbt-launch.jar
```
