### PR TITLE
Store sbt jars within user's home if script_dir is not writable

### DIFF
--- a/sbt
+++ b/sbt
@@ -137,6 +137,9 @@ declare -a sbt_commands
 # if set, use JAVA_HOME over java found in path
 [[ -e "$JAVA_HOME/bin/java" ]] && java_cmd="$JAVA_HOME/bin/java"
 
+# use ~/.sbt/launch to store sbt jars if script_dir is not writable
+[[ -w "$sbt_launch_dir" ]] || sbt_launch_dir="$HOME/.sbt/launch"
+
 build_props_scala () {
   if [[ -f project/build.properties ]]; then
     versionLine=$(grep ^build.scala.versions project/build.properties)


### PR DESCRIPTION
Store sbt jars within user's home if the `$script_dir` is not writable. We need this to share script across users.

For backward compatibility, no behaviors are changed if `$script_dir/.lib` is writable. Otherwise, use `~/.sbt/launch` as `$script_dir`.
