### PR TITLE
OpenJDK 6 and 7 issues with CMSClassUnloadingEnabled being set without UseConcMarkSweepGC

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ well as a snapshot version of scala, then run the sbt "about" command.
     # Executing command line:
     java
     -XX:+CMSClassUnloadingEnabled
+    -XX:+UseConcMarkSweepGC
     -Xms1536m
     -Xmx1536m
     -XX:MaxPermSize=384m
@@ -96,7 +97,7 @@ Current -help output:
 
       # jvm options and output control
       JAVA_OPTS     environment variable holding jvm args, if unset uses "-Dfile.encoding=UTF8"
-      SBT_OPTS      environment variable holding jvm args, if unset uses "-XX:+CMSClassUnloadingEnabled"
+      SBT_OPTS      environment variable holding jvm args, if unset uses "-XX:+CMSClassUnloadingEnabled -XX:+UseConcMarkSweepGC"
       .jvmopts      if file is in sbt root, it is prepended to the args given to the jvm
       .sbtopts      if file is in sbt root, it is prepended to the args given to **sbt**
       -Dkey=val     pass -Dkey=val directly to the jvm

--- a/sbt
+++ b/sbt
@@ -106,7 +106,7 @@ make_url () {
 }
 
 declare -r default_jvm_opts="-Dfile.encoding=UTF8"
-declare -r default_sbt_opts="-XX:+CMSClassUnloadingEnabled"
+declare -r default_sbt_opts="-XX:+CMSClassUnloadingEnabled -XX:+UseConcMarkSweepGC"
 declare -r default_sbt_mem=1536
 declare -r default_trace_level=15
 declare -r noshare_opts="-Dsbt.global.base=project/.sbtboot -Dsbt.boot.directory=project/.boot -Dsbt.ivy.home=project/.ivy"


### PR DESCRIPTION
OpenJDK 6 and 7 by default have UseConcMarkSweepGC disabled. Thus, setting just CMSClassUnloadingEnabled will not work as intended. This can be verified by examining the OpenJDK 6 and 7 source. /hotspot/src/share/vm/runtime/globals.hpp declares it as false by default and the only GC where it is used is /hotspot/src/share/vm/gc_implementation/concurrentMarkSweep/concurrentMarkSweepGeneration.cpp.

Note: It is possible for the CMS GC to be automatically selected, as defined in arguments.cpp. However, explicitly stating it would assure its use.
