### PR TITLE
Strip CR characters from build.properties when detecting the sbt version

### DIFF
--- a/sbt
+++ b/sbt
@@ -20,7 +20,7 @@ done
 
 build_props_sbt () {
   if [[ -r project/build.properties ]]; then
-    versionLine=$(grep ^sbt.version project/build.properties)
+    versionLine=$(grep ^sbt.version project/build.properties | tr -d '\r')
     versionString=${versionLine##sbt.version=}
     echo "$versionString"
   fi


### PR DESCRIPTION
If the sbt.version line in build.properties ends with CRLF (for example,
after being copied over from a Windows machine) instead of LF, the CR
needs to be stripped off so as to not become a part of the version number
(which makes downloading of the required launcher jar fail with very
strange console output due to those control characters).
