### PR TITLE
fix broken `-no-share`

### DIFF
--- a/sbt
+++ b/sbt
@@ -455,7 +455,9 @@ EOM
 }
 
 if [[ -n $noshare ]]; then
-  addJava "$noshare_opts"
+  for opt in ${noshare_opts}; do
+    addJava "$opt"
+  done
 else
   [[ -n "$sbt_dir" ]] || {
     sbt_dir=~/.sbt/$(sbt_version)


### PR DESCRIPTION
Fix broken `-no-share`.

Because `addJava` cannot handle multiple options at once, iterate over `noshare_opts` to add them as JVM options.
