### PR TITLE
Always prepend residual_args with 'shell' in interactive mode

### DIFF
--- a/sbt
+++ b/sbt
@@ -472,8 +472,7 @@ else
   extra_jvm_opts=( $default_jvm_opts )
 fi
 
-# since sbt 0.7 doesn't understand iflast
-[[ ${#residual_args[@]} -eq 0 ]] && [[ -z "$batch" ]] && residual_args=( "shell" )
+[[ -z "$batch" ]] && residual_args=( "shell" ${residual_args[@]} )
 
 # traceLevel is 0.12+
 [[ -n $trace_level ]] && setTraceLevel


### PR DESCRIPTION
If there are SBT_OPTS defined residual_args will be non empty and 'shell' argument will not be included in args list.
This prevents sbt from going into interactive mode. 
This fix assumes that only '-batch' option must lead to 'shell' arg being omitted from args list.
