### PR TITLE
Ups default_jvm_opts max heap size and thread stack size

### DIFF
--- a/sbt
+++ b/sbt
@@ -124,7 +124,7 @@ init_default_option_file () {
   echo $default_file
 }
 
-declare -r default_jvm_opts="-Dfile.encoding=UTF8 -XX:MaxPermSize=256m -Xms512m -Xmx1g -XX:+CMSClassUnloadingEnabled -XX:+UseConcMarkSweepGC"
+declare -r default_jvm_opts="-Dfile.encoding=UTF8 -XX:MaxPermSize=256m -Xms512m -Xmx2g -XX:+CMSClassUnloadingEnabled -XX:+UseConcMarkSweepGC -Xss2m"
 declare -r noshare_opts="-Dsbt.global.base=project/.sbtboot -Dsbt.boot.directory=project/.boot -Dsbt.ivy.home=project/.ivy"
 declare -r latest_28="2.8.2"
 declare -r latest_29="2.9.3"


### PR DESCRIPTION
sbt 0.11.3 stack overflows on large Play Framework projects. Sets `-Xmx2g`
and `-Xss2m` to fix memory issues when compiling.
#55
