### PR TITLE
Add '-211', update '-210' and fix README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,37 +16,52 @@ It is a good idea to uninstall any pre-existing sbt installations you may have.
 
 ## Sample usage
 
-Sample usage: create a new project using a snapshot version of sbt as
-well as a snapshot version of scala, then run the sbt "about" command.
+Sample usage: create a new project using snapshot version of scala 2.11.0, then run the sbt "about" command.
 
-    % sbt -v -sbt-snapshot -210 -sbt-create about
-    Detected sbt version 0.11.3-SNAPSHOT
-    sbt snapshot is 0.11.3-20111207-052114
+    % sbt -v -scala-version 2.11.0-SNAPSHOT -sbt-create about
+    No extra sbt options have been defined
+    Detected sbt version 0.13.0
+    Using /Users/paulp/.sbt/0.13.0 as sbt dir, -sbt-dir to override.
+    Using default jvm options
     # Executing command line:
     java
+    -Dfile.encoding=UTF8
+    -XX:MaxPermSize=256m
+    -Xms512m
+    -Xmx1g
     -XX:+CMSClassUnloadingEnabled
     -XX:+UseConcMarkSweepGC
-    -Xms1536m
-    -Xmx1536m
-    -XX:MaxPermSize=384m
-    -XX:ReservedCodeCacheSize=192m
-    -Dfile.encoding=UTF8
     -jar
-    /r/sbt-extras/.lib/0.11.3-SNAPSHOT/sbt-launch.jar
-    "set resolvers in ThisBuild += ScalaToolsSnapshots"
-    "++ 2.10.0-SNAPSHOT"
+    /Users/paulp/.sbt/launchers/0.13.0/sbt-launch.jar
+    "set resolvers += Resolver.sonatypeRepo("snapshots")"
+    "++ "2.11.0-SNAPSHOT""
     about
 
-    [info] Loading global plugins from /Users/paulp/.sbt/plugins
     [info] Set current project to default-71999b (in build file:/Users/paulp/Desktop/new/)
+    [info] Defining *:resolvers
+    [info] The new value will be used by *:externalResolvers
     [info] Reapplying settings...
     [info] Set current project to default-71999b (in build file:/Users/paulp/Desktop/new/)
-    Setting version to 2.10.0-SNAPSHOT
+    [info] Setting version to 2.11.0-SNAPSHOT
     [info] Set current project to default-71999b (in build file:/Users/paulp/Desktop/new/)
-    [info] This is sbt 0.11.3-20111207-052114
+    [info] Updating {file:/Users/paulp/Desktop/new/}default-71999b...
+    [info] Resolving jline#jline;2.11 ...
+    [info] downloading https://oss.sonatype.org/content/repositories/snapshots/org/scala-lang/scala-library/2.11.0-SNAPSHOT/scala-library-2.11.0-20130827.010728-375.jar ...
+    [info]  [SUCCESSFUL ] org.scala-lang#scala-library;2.11.0-SNAPSHOT!scala-library.jar (87077ms)
+    [info] downloading https://oss.sonatype.org/content/repositories/snapshots/org/scala-lang/scala-compiler/2.11.0-SNAPSHOT/scala-compiler-2.11.0-20130827.010728-374.jar ...
+    [info]  [SUCCESSFUL ] org.scala-lang#scala-compiler;2.11.0-SNAPSHOT!scala-compiler.jar (58319ms)
+    [info] downloading https://oss.sonatype.org/content/repositories/snapshots/org/scala-lang/scala-xml/2.11.0-SNAPSHOT/scala-xml-2.11.0-20130827.010728-46.jar ...
+    [info]  [SUCCESSFUL ] org.scala-lang#scala-xml;2.11.0-SNAPSHOT!scala-xml.jar (5290ms)
+    [info] downloading https://oss.sonatype.org/content/repositories/snapshots/org/scala-lang/scala-parser-combinators/2.11.0-SNAPSHOT/scala-parser-combinators-2.11.0-20130827.010728-46.jar ...
+    [info]  [SUCCESSFUL ] org.scala-lang#scala-parser-combinators;2.11.0-SNAPSHOT!scala-parser-combinators.jar (19014ms)
+    [info] downloading https://oss.sonatype.org/content/repositories/snapshots/org/scala-lang/scala-reflect/2.11.0-SNAPSHOT/scala-reflect-2.11.0-20130827.010728-374.jar ...
+    [info]  [SUCCESSFUL ] org.scala-lang#scala-reflect;2.11.0-SNAPSHOT!scala-reflect.jar (15601ms)
+    [info] Done updating.
+    [info] This is sbt 0.13.0
     [info] The current project is {file:/Users/paulp/Desktop/new/}default-71999b
-    [info] The current project is built against Scala 2.10.0-SNAPSHOT
-    [info] sbt, sbt plugins, and build definitions are using Scala 2.9.1
+    [info] The current project is built against Scala 2.11.0-SNAPSHOT
+    [info]
+    [info] sbt, sbt plugins, and build definitions are using Scala 2.10.2
 
 Sample, contrived usage of `prompt` option, using both `e` and `s`:
 
@@ -81,13 +96,13 @@ Current -help output:
       !!! contains an sbt.version property is to update the file on disk.  That's what this does.
       -sbt-version  <version>   use the specified version of sbt
       -sbt-jar      <path>      use the specified jar as the sbt launcher
-      -sbt-snapshot             use a snapshot version of sbt
       -sbt-launch-dir <path>    directory to hold sbt launchers (default: ./.lib)
 
       # scala version (default: as chosen by sbt)
       -28                       use 2.8.2
       -29                       use 2.9.3
-      -210                      use 2.10.0
+      -210                      use 2.10.3-RC1
+      -211                      use 2.11.0-M4
       -scala-home <path>        use the scala build at the specified directory
       -scala-version <version>  use the specified version of scala
       -binary-version <version> use the specified scala version when searching for dependencies

--- a/sbt
+++ b/sbt
@@ -126,7 +126,8 @@ declare -r default_jvm_opts="-Dfile.encoding=UTF8 -XX:MaxPermSize=256m -Xms512m 
 declare -r noshare_opts="-Dsbt.global.base=project/.sbtboot -Dsbt.boot.directory=project/.boot -Dsbt.ivy.home=project/.ivy"
 declare -r latest_28="2.8.2"
 declare -r latest_29="2.9.3"
-declare -r latest_210="2.10.3"
+declare -r latest_210="2.10.3-RC1"
+declare -r latest_211="2.11.0-M4"
 
 declare -r script_path=$(get_script_path "$BASH_SOURCE")
 declare -r script_dir="$(dirname $script_path)"
@@ -371,6 +372,7 @@ process_args ()
             -28) addSbt "++ $latest_28" && shift ;;
             -29) addSbt "++ $latest_29" && shift ;;
            -210) addSbt "++ $latest_210" && shift ;;
+           -211) addSbt "++ $latest_211" && shift ;;
 
               *) addResidual "$1" && shift ;;
     esac


### PR DESCRIPTION
This pull request is primarily thought to get clarifications from @paulp (based on your answers, these proposed changes may be totally invalid. I hope it won't bother or hurt too much): 

After reading/fixing README.md, I'm not sure what is the "current" purpose of options like `-210`, `-29` (it seems like "long time ago" it was used to refer to the SNAPSHOT versions). I see like three possible variants:

a) latest **final** releases (e.g. 2.10.2). In this case, the addition of `-211` is proposed too early, but `-210` is already set to 2.10.3, which is not yet released.

or

b) latest release including release candidates and other tagged milestones (e.g. 2.11.0-M4  or 2.10.3-RC1)

or

c) snapshots (e.g. 2.11.0-SNAPSHOT)

In this PR and also in #58, I assumed that you removed on the long term the support of `-sbt-snapshot` option (but f19a3e4fe1dab69c06e249a2db3cc1934b7bf4b9 sounds maybe like a temporary workaround). Do you plan to re-introduce this option later? I wonder if it has been removed by accident while removing support of "scala snapshots" (certainly in relation with sbt/sbt#856). BTW, I noticed there was a `http://`duplicate typo in [url="http://http://repo.typesafe.com..."](https://github.com/paulp/sbt-extras/commit/f19a3e4fe1dab69c06e249a2db3cc1934b7bf4b9#L0L204).

Many thanks in advance for your clarifications!
