### PR TITLE
Fix Batch Mode

### DIFF
--- a/sbt
+++ b/sbt
@@ -73,11 +73,9 @@ onSbtRunnerExit() {
 }
 
 # save stty and trap exit, to ensure echo is reenabled if we are interrupted.
-if [[ -n $batch ]]; then
-  trap onSbtRunnerExit EXIT
-  sbt_saved_stty=$(stty -g 2>/dev/null)
-  dlog "Saved stty: $sbt_saved_stty"
-fi
+trap onSbtRunnerExit EXIT
+sbt_saved_stty=$(stty -g 2>/dev/null)
+dlog "Saved stty: $sbt_saved_stty"
 
 # this seems to cover the bases on OSX, and someone will
 # have to tell me about the others.
@@ -182,14 +180,9 @@ execRunner () {
   }
 
   if [[ -n $batch ]]; then
-    # the only effective way I've found to avoid sbt hanging when backgrounded.
-    exec 0<&-
-    ( "$@" & )
-    # I'm sure there's some way to get our hands on the pid and wait for it
-    # but it exceeds my present level of ambition.
-  else
-    { "$@"; }
+    exec </dev/null
   fi
+  exec "$@"
 }
 
 jar_url () {
@@ -418,8 +411,7 @@ vlog "Detected sbt version $(sbt_version)"
 # no args - alert them there's stuff in here
 (( $argumentCount > 0 )) || {
   vlog "Starting $script_name: invoke with -help for other options"
-  # Unless in batch mode, add shell to the empty args
-  [[ -n "$batch" ]] || residual_args=( shell )
+  residual_args=( shell )
 }
 
 # verify this is an sbt dir or -create was given


### PR DESCRIPTION
In continuation to #57 and #42, I propose here to:
- fix **`-batch` option**
- **aborted (see comments below):** auto-detect if running in background (`&`) and act accordingly, so that sbt execution is not interrupted.

Here a few more details about addressing #42:
Like @paulp in previous commit (f8a0213), I don't propose any fix to wait and catch exit code of sbt run (running in background already means some loss of interest on this value, I guess). For the records, I attempted tricks with things like `wait $!`, `sleep`, `disown`, `nohup`, ... but both (parent script and sbt launcher) processes always get **stopped** when such builtins are called. I shortly gave up to investigate on this, since I'm personally only interested in `-batch` mode. @kim0 could you please confirm that it meets your needs?
