### PR TITLE
add Xs to 'mktemp' template for *nix

### DIFF
--- a/sbt
+++ b/sbt
@@ -151,7 +151,7 @@ declare -a extra_jvm_opts extra_sbt_opts
 # directory to store sbt launchers
 declare sbt_launch_dir="$HOME/.sbt/launchers"
 [[ -d "$sbt_launch_dir" ]] || mkdir -p "$sbt_launch_dir"
-[[ -w "$sbt_launch_dir" ]] || sbt_launch_dir="$(mktemp -d -t sbt_extras_launchers)"
+[[ -w "$sbt_launch_dir" ]] || sbt_launch_dir="$(mktemp -d -t sbt_extras_launchers.XXXXXX)"
 
 build_props_scala () {
   if [[ -r $buildProps ]]; then


### PR DESCRIPTION
`mktemp` needs at least 3 Xs in the template on *nix, otherwise you get an error:

```
STDERR: mktemp: too few X's in template `sbt_extras_launchers'
```

Tested on Vagrant base box `Berkshelf-CentOS-6.3-x86_64-minimal` on an Ubuntu host system.

On Mac it will just end up creating `/var/tmp/<random>/sbt_extras_launchers.XXXXXX.<random>`
