### PR TITLE
Fix comment skipping code.

### DIFF
--- a/sbt
+++ b/sbt
@@ -366,9 +366,11 @@ process_args ()
 # process the direct command line arguments
 process_args "$@"
 
-# skip #-styled comments
+# skip #-styled comments and blank lines
 readConfigFile() {
-  while read line; do echo "${line/\#.*/}"; done < "$1"
+  while read line; do
+    [[ $line =~ ^# ]] || [[ -z $line ]] || echo "$line"
+  done < "$1"
 }
 
 # if there are file/environment sbt_opts, process again so we

--- a/test/config-file.bats
+++ b/test/config-file.bats
@@ -1,0 +1,41 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+setup() {
+  create_project
+  create_launcher "${sbt_release_version}"
+}
+
+stub_java() {
+  stub java 'for arg; do echo "$arg"; done'
+}
+
+configFile () { cat <<EOM
+# Comment 1
+# Comment 2, followed by blank line
+
+-Xmx1g
+
+-Xss4m
+# Comment 4
+EOM
+}
+
+expectedOutput () { cat <<EOM
+-Xmx1g
+-Xss4m
+-jar
+${TMP}/.sbt/launchers/0.13.1/sbt-launch.jar
+about
+EOM
+}
+
+@test "tolerates blank lines and comments in jvm_opts file" {
+  stub_java
+  configFile >jvm_opts
+  run sbt -jvm-opts jvm_opts about
+  assert_success
+  expectedOutput | assert_output
+  unstub java
+}

--- a/test/test_helper.bash
+++ b/test/test_helper.bash
@@ -1,10 +1,6 @@
 export TMP="$BATS_TEST_DIRNAME/tmp"
 export HOME="$TMP"
-
-PATH=/usr/bin:/usr/sbin:/bin/:/sbin
-PATH="$BATS_TEST_DIRNAME/../bin:$PATH"
-PATH="$TMP/bin:$PATH"
-export PATH
+export PATH="$BATS_TEST_DIRNAME/../bin:$TMP/bin:/usr/bin:/usr/sbin:/bin:/sbin"
 
 unset JAVA_HOME
 unset JVM_OPTS


### PR DESCRIPTION
Didn't work at all, amazingly enough - it was using regexp
style instead of globbing. Also broke in the face of blank lines.
jvm_opts files can now contain lines starting a # and blank lines,
but lines with a non-initial # are options.

Used new testing abilities to include a test. Whoo.
