### PR TITLE
Change curl statement in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ required versions of sbt and scala, downloading them if necessary.
 
 Put the (self-contained) [sbt script](https://raw.githubusercontent.com/paulp/sbt-extras/master/sbt "sbt") somewhere on your path.
 
-    curl -s https://raw.githubusercontent.com/paulp/sbt-extras/master/sbt > ~/bin/sbt && chmod 0755 ~/bin/sbt
+    curl -Lo ~/bin/sbt http://tinyurl.com/paulp-sbt && chmod 0755 ~/bin/sbt
 
 ## Sample usage
 


### PR DESCRIPTION
For reference:

```
$ curl -iw '\n' http://tinyurl.com/paulp-sbt
HTTP/1.1 301 Moved Permanently
X-Powered-By: PHP/5.4.27
Location: https://github.com/paulp/sbt-extras/raw/master/sbt
X-tiny: cache 0.010701179504395
Content-Type: text/html
Content-Length: 0
Server: TinyURL/1.6
Date: Tue, 15 Jul 2014 06:29:02 GMT
Connection: keep-alive
Set-Cookie: tinyUUID=3c4ca32a077a4e951a99e048; expires=Wed, 15-Jul-2015
06:29:01 GMT; path=/; domain=.tinyurl.com

$ curl -iw '\n' https://github.com/paulp/sbt-extras/raw/master/sbt
HTTP/1.1 302 Found
Server: GitHub.com
Date: Tue, 15 Jul 2014 06:29:08 GMT
Content-Type: text/html; charset=utf-8
Status: 302 Found
Cache-Control: no-cache
X-XSS-Protection: 1; mode=block
X-Frame-Options: deny
Content-Security-Policy: default-src *; script-src assets-cdn.github.com
www.google-analytics.com collector-cdn.github.com; object-src
assets-cdn.github.com; style-src 'self' 'unsafe-inline' 'unsafe-eval'
assets-cdn.github.com; img-src 'self' data: assets-cdn.github.com
identicons.github.com www.google-analytics.com collector.githubapp.com
*.githubusercontent.com *.gravatar.com *.wp.com; media-src 'none';
frame-src 'self' render.githubusercontent.com www.youtube.com
assets.braintreegateway.com; font-src assets-cdn.github.com; connect-src
'self' ghconduit.com:25035 live.github.com uploads.github.com
s3.amazonaws.com
Vary: X-PJAX
X-RateLimit-Limit: 100
X-RateLimit-Remaining: 100
Access-Control-Allow-Origin: https://render.githubusercontent.com
Location: https://raw.githubusercontent.com/paulp/sbt-extras/master/sbt
Content-Length: 127
Set-Cookie:
_gh_sess=eyJzZXNzaW9uX2lkIjoiZDI5NDE2NzBjZjJjZWJiYWIyN2FmYmJkYWNiNzk4MjciLCJzcHlfcmVwbyI6InBhdWxwL3NidC1leHRyYXMiLCJzcHlfcmVwb19hdCI6MTQwNTQwNTc0OH0%3D--e6ca04c9ea85b880cf2dae3a59bb2a950e8a5a07;
path=/; secure; HttpOnly
X-GitHub-Request-Id: 4E951A99:1160:7E26AAA:53C4CA34
Strict-Transport-Security: max-age=31536000; includeSubdomains
X-Content-Type-Options: nosniff
Vary: Accept-Encoding
X-Served-By: bc4c952d089501afbfc8f7ff525da31c

<html><body>You are being <a
href="https://raw.githubusercontent.com/paulp/sbt-extras/master/sbt">redirected</a>.</body></html>
```
