### PR TITLE
No longer runs build twice when mainFiltered fails.

### DIFF
--- a/sbt
+++ b/sbt
@@ -522,4 +522,4 @@ mainFiltered () {
 shouldFilter () { [[ -f ~/.sbtignore ]] && ! egrep -q '\b(shell|console|consoleProject)\b' <<<"${residual_args[@]}"; }
 
 # run sbt
-shouldFilter && mainFiltered || main
+if shouldFilter; then mainFiltered; else main; fi


### PR DESCRIPTION
Found that when the mainFiltered command fails the script will run the main command, effectively trying to build twice.  Quick fix to stop that from happening.
