### PR TITLE
Fix per-version sbt plugin from .sbt support for 0.13.*

### DIFF
--- a/sbt
+++ b/sbt
@@ -453,7 +453,7 @@ if [[ -n "$noshare" ]]; then
   done
 else
   case "$sbt_version" in
-    "0.7."* | "0.10."* | "0.11."* | "0.12."* )
+    "0.7."* | "0.10."* | "0.11."* | "0.12."* | "0.13."*)
       [[ -n "$sbt_dir" ]] || {
         sbt_dir="$HOME/.sbt/$sbt_version"
         vlog "Using $sbt_dir as sbt dir, -sbt-dir to override."


### PR DESCRIPTION
Before this changeset, here's the output from a project setup with sbt version 0.13.5
  [info] Loading global plugins from /Users/irfan/.sbt/0.13/plugins/project
  [info] Loading global plugins from /Users/irfan/.sbt/0.13/plugins

With this changeset, the output for the same project
  [info] Loading global plugins from /Users/irfan/.sbt/0.13.5/plugins
