### PR TITLE
Fix #349 - sbtextras should respect spaces within lines of .jvmopts

### DIFF
--- a/sbt
+++ b/sbt
@@ -542,7 +542,7 @@ readConfigFile() {
 # can supply args to this runner
 if [[ -r "$sbt_opts_file" ]]; then
   vlog "Using sbt options defined in file $sbt_opts_file"
-  while read -r opt; do extra_sbt_opts+=("$opt"); done < <(readConfigFile "$sbt_opts_file")
+  extra_sbt_opts+=($(readConfigFile "$sbt_opts_file"))
 elif [[ -n "$SBT_OPTS" && ! ("$SBT_OPTS" =~ ^@.*) ]]; then
   vlog "Using sbt options defined in variable \$SBT_OPTS"
   IFS=" " read -r -a extra_sbt_opts <<<"$SBT_OPTS"

--- a/sbt
+++ b/sbt
@@ -644,7 +644,7 @@ fi
 
 if [[ -r "$jvm_opts_file" ]]; then
   vlog "Using jvm options defined in file $jvm_opts_file"
-  while read -r opt; do extra_jvm_opts+=("$opt"); done < <(readConfigFile "$jvm_opts_file")
+  extra_jvm_opts+=($(readConfigFile "$jvm_opts_file"))
 elif [[ -n "$JVM_OPTS" && ! ("$JVM_OPTS" =~ ^@.*) ]]; then
   vlog "Using jvm options defined in \$JVM_OPTS variable"
   IFS=" " read -r -a extra_jvm_opts <<<"$JVM_OPTS"

--- a/sbt
+++ b/sbt
@@ -554,7 +554,7 @@ fi
 # can supply args to this runner
 if [[ -r "$sbtx_opts_file" ]]; then
   vlog "Using sbt options defined in file $sbtx_opts_file"
-  while read -r opt; do extra_sbt_opts+=("$opt"); done < <(readConfigFile "$sbtx_opts_file")
+  extra_sbt_opts+=($(readConfigFile "$sbtx_opts_file"))
 elif [[ -n "$SBTX_OPTS" && ! ("$SBTX_OPTS" =~ ^@.*) ]]; then
   vlog "Using sbt options defined in variable \$SBTX_OPTS"
   IFS=" " read -r -a extra_sbt_opts <<<"$SBTX_OPTS"


### PR DESCRIPTION
Fix #349 - sbtextras should respect spaces within lines of .jvmopts as a property separator

- Leverage the parsing of the file into tokens already done by the readConfigFile function
- Append these tokens, which were already split by newlines *and* spaces to the extra_jvm_opts array

## Notes
I tested this changeset and verified the results using the workflow described within #349.

Given the following script, run from the root of this project:

```sh
#!/usr/bin/env bash

mkdir -p sbtx-vs-sbt-jvmopts
cd sbtx-vs-sbt-jvmopts
mkdir -p project
echo 'sbt.version=1.7.1' > project/build.properties
echo '-Daaa=bbb -Dccc=ddd' > .jvmopts
echo '-Dxxx=yyy' >> .jvmopts
echo 'object TheApp extends App { sys.props.foreach(println) }' > TheApp.scala

# Run the app with the sbt/sbt launcher:
echo "sbt output:"
sbt run

# Run the app with sbtextras
echo "sbtextras output:"
../sbt run
```

The [sbt/sbt](https://github.com/sbt/sbt) launcher will output the following discrete JVM properties:
`(aaa,bbb)`
`(ccc,ddd)`
`(xxx,yyy)`

And now, after this change set is applied, sbtextras will also correctly output the following JVM properties:
`(aaa,bbb)`
`(ccc,ddd)`
`(xxx,yyy)`

If you run this routine on the current HEAD of master, sbtextras will incorrectly output:
`(aaa,bbb -Dccc=ddd)`
`(xxx,yyy)`
