### PR TITLE
Enable support for internal jdk

### DIFF
--- a/sbt
+++ b/sbt
@@ -217,7 +217,8 @@ getJavaVersion() {
   if [[ "$str" =~ ^1\.([0-9]+)(\..*)?$ ]]; then
     echo "${BASH_REMATCH[1]}"
   # Fixes https://github.com/dwijnand/sbt-extras/issues/326
-  elif [[ "$str" =~ ^([0-9]+)(\..*)?(-ea)?$ ]]; then
+  # Fixes https://github.com/dwijnand/sbt-extras/issues/378
+  elif [[ "$str" =~ ^([0-9]+)(\..*)?-(ea|internal)?$ ]]; then
     echo "${BASH_REMATCH[1]}"
   elif [[ -n "$str" ]]; then
     echoerr "Can't parse java version from: $str"


### PR DESCRIPTION
Hi,

( I'm new to sbt-extras, please kindly let me know if I need to follow some process for this pr. )
Can you have a look at this minor patch? This is to bring mior improvement to the `sbt` script: Enable support for internal jdk.
Please check details in https://github.com/dwijnand/sbt-extras/issues/378

Thanks!